### PR TITLE
Add createSubscriber

### DIFF
--- a/modules/__tests__/integration-test.js
+++ b/modules/__tests__/integration-test.js
@@ -5,6 +5,7 @@ import { render } from 'react-dom'
 import expect from 'expect'
 import { EventEmitter } from 'events'
 import { Subscriber, Broadcast } from '../index'
+import createSubscriber from '../createSubscriber'
 
 it('works', (done) => {
 
@@ -21,6 +22,13 @@ it('works', (done) => {
     <Broadcast channel="cheese" value={cheese} children={children}/>
   const CheeseSubscriber = ({ children }) =>
     <Subscriber channel="cheese">{(value) => children(value)}</Subscriber>
+
+  const ConnectCheese = ({ cheese }) => {
+    actualCheeseConnect = cheese
+     return (<div></div>)
+   }
+  const ConnectCheeseSubscriber = createSubscriber("cheese")(ConnectCheese)
+
 
   class ComponentWithStateForDescendants extends React.Component {
     constructor() {
@@ -48,14 +56,17 @@ it('works', (done) => {
   }
 
   let actualCheese = null
+  let actualCheeseConnect = null
 
   steps.push(
     () => {
       expect(actualCheese).toBe('cheddar')
+      expect(actualCheeseConnect).toBe('cheddar')
       emitter.emit('CHEESE', 'gouda')
     },
     () => {
       expect(actualCheese).toBe('gouda')
+      expect(actualCheeseConnect).toBe('gouda')
       done()
     }
   )
@@ -64,13 +75,16 @@ it('works', (done) => {
   //    gets a new value in its prop
   render((
     <ComponentWithStateForDescendants>
-      <CheeseSubscriber>
-        {(cheese) => {
-          actualCheese = cheese
-          return null
-        }}
-      </CheeseSubscriber>
+      <div>
+        <CheeseSubscriber>
+          {(cheese) => {
+            actualCheese = cheese
+            return null
+          }}
+        </CheeseSubscriber>
+        <ConnectCheeseSubscriber>
+        </ConnectCheeseSubscriber>
+      </div>
     </ComponentWithStateForDescendants>
   ), div)
 })
-

--- a/modules/createSubscriber.js
+++ b/modules/createSubscriber.js
@@ -1,0 +1,53 @@
+import invariant from 'invariant'
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const createSubscriber = channel => BaseComponent => {
+  return class Subscriber extends React.Component {
+    static contextTypes = {
+      broadcasts: PropTypes.object
+    }
+
+    state = {
+      value: null
+    }
+
+    getBroadcast() {
+      const broadcast = this.context.broadcasts[channel]
+
+      invariant(
+        broadcast,
+        '<Subscriber channel="%s"> must be rendered in the context of a <Broadcast channel="%s">',
+        this.channel,
+        this.channel
+      )
+
+      return broadcast
+    }
+
+    componentWillMount() {
+      const broadcast = this.getBroadcast()
+      this.setState({
+        value: broadcast.getState()
+      })
+    }
+
+    componentDidMount() {
+      const broadcast = this.getBroadcast()
+      this.unsubscribe = broadcast.subscribe(value => {
+        this.setState({ value })
+      })
+    }
+
+    componentWillUnmount() {
+      this.unsubscribe()
+    }
+
+    render() {
+      const props = {...this.props, [channel]: this.state.value }
+      return <BaseComponent {...props} />
+    }
+  }
+}
+
+export default createSubscriber

--- a/modules/createSubscriber.js
+++ b/modules/createSubscriber.js
@@ -2,6 +2,11 @@ import invariant from 'invariant'
 import React from 'react'
 import PropTypes from 'prop-types'
 
+/**
+ * Higher order component that takes in a channel name and BaseComponent and
+ * returns a <Subscriber> which pulls the value for a channel off of
+ * context.broadcasts and passes it as prop down to it's BaseComponent.
+ */
 const createSubscriber = channel => BaseComponent => {
   return class Subscriber extends React.Component {
     static contextTypes = {


### PR DESCRIPTION
Add `createSubscriber` function that passes down the value of for the channel as prop to the passed in based component.

In certain use cases having a `createSubscriber` function could be more handy than creating an extra `Subscriber` component for each channel.

Currently it basically returns a `Subscriber` component that looks almost the same as the `Subscriber` component. Happy for any ideas to combine the code somehow if you would like to go forward with it.