### PR TITLE
fix(package): add module and main entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "react-broadcast",
   "version": "0.3.1",
+  "main": "index.js",
+  "module": "es/index.js",
   "description": "A reliable way to broadcast state changes to React elements deep in the hierarchy",
   "repository": "ReactTraining/react-broadcast",
   "license": "MIT",


### PR DESCRIPTION
Thanks for this great library! 

While trying to integrate it into my project I noticed that I ended up with two versions of React in my bundles. I assume that this is, apart from my setup, due to the fact that the `package.json` does not contain a `main` and `module` entry to resolve to specific builds when bundling with `webpack` or `rollup`.