### PR TITLE
Add typescript typedefs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+declare module "react-broadcast" {
+  import { ComponentClass } from "react"
+
+  namespace ReactBroadcast {
+    interface BroadcastProps {
+      channel: string,
+      value?: any
+    }
+
+    interface SubscriberProps {
+      channel: string
+    }
+
+    const Broadcast: ComponentClass<BroadcastProps>
+    const Subscriber: ComponentClass<SubscriberProps>
+  }
+
+  export = ReactBroadcast
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "cjs/react-broadcast.js",
   "module": "esm/react-broadcast.js",
   "unpkg": "umd/react-broadcast.js",
+  "typings": "./index.d.ts",
   "scripts": {
     "build": "node ./scripts/build.js",
     "clean": "git clean -fdX .",


### PR DESCRIPTION
This is a simple typedef for react-broadcast. I've exported the prop definitions alongside the components themselves, in case someone needs to mix the props in to one of their related react components.