### PR TITLE
remove React.Children.only() from Broadcast

### DIFF
--- a/modules/Broadcast.js
+++ b/modules/Broadcast.js
@@ -74,7 +74,7 @@ class Broadcast extends React.Component {
   }
 
   render() {
-    return React.Children.only(this.props.children)
+    return this.props.children
   }
 }
 


### PR DESCRIPTION
It seems like there is no reason why Broadcast can't accept more than one child