### PR TITLE
Ensure proper Invariant Violation error is thrown

### DIFF
--- a/modules/Subscriber.js
+++ b/modules/Subscriber.js
@@ -21,7 +21,8 @@ class Subscriber extends React.Component {
   }
 
   getBroadcast() {
-    const broadcast = this.context.broadcasts[this.props.channel]
+    const broadcasts = this.context.broadcasts || {}
+    const broadcast = broadcasts[this.props.channel]
 
     invariant(
       broadcast,

--- a/modules/__tests__/integration-test.js
+++ b/modules/__tests__/integration-test.js
@@ -71,3 +71,15 @@ it('works', (done) => {
     </ComponentWithStateForDescendants>
   ), div)
 })
+
+it('Throws an invariant violation when a subscriber is rendered outside of a broadcast', () => {
+  const renderSubscriberOnly = () => {
+    ReactDOM.render((
+      <Subscriber channel="test">
+        {() => null}
+      </Subscriber>
+    ), document.createElement('div'))
+  }
+
+  expect(renderSubscriberOnly).toThrow(/<Subscriber channel="test">.*<Broadcast channel="test".*/)
+})


### PR DESCRIPTION
Ensure a proper Invariant Violation error is thrown when a <Subscriber> is rendered outside of a <Broadcast>, instead of a TypeError