### PR TITLE
Include ability to supply a compare function

### DIFF
--- a/modules/Broadcast.js
+++ b/modules/Broadcast.js
@@ -40,6 +40,7 @@ const createBroadcast = (initialState) => {
 class Broadcast extends React.Component {
   static propTypes = {
     channel: PropTypes.string.isRequired,
+    compareFunction: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
     value: PropTypes.any
   }
@@ -69,13 +70,17 @@ class Broadcast extends React.Component {
       'You cannot change <Broadcast channel>'
     )
 
-    if (this.props.value !== nextProps.value)
+    if (this.props.compareFunction(this.props.value, nextProps.value))
       this.broadcast.setState(nextProps.value)
   }
 
   render() {
     return React.Children.only(this.props.children)
   }
+}
+
+Broadcast.defaultProps = {
+  compareFunction: (value, nextValue) => value !== nextValue
 }
 
 export default Broadcast


### PR DESCRIPTION
Hey @mjackson / @ryanflorence! 

We use `react-broadcast` at Webflow (webflow.com) and have need to perform deep equality checks vs. the reference check that's the default in `Broadcast`. This was wreaking some re-rendering havoc in our app as we don't pass immutable structures through our broadcasts. 😬 It would be fantastic if we could supply our own compare function to avoid those. I hope this makes sense! Thanks. 😄 

