### PR TITLE
Add provide and consume functions

### DIFF
--- a/modules/__tests__/createContext-test.js
+++ b/modules/__tests__/createContext-test.js
@@ -13,6 +13,16 @@ describe("createContext", () => {
     const { Consumer } = createContext();
     expect(typeof Consumer).toBe("function");
   });
+
+  it("provides a provide function", () => {
+    const { provide } = createContext();
+    expect(typeof provide).toBe("function");
+  });
+
+  it("provides a consume function", () => {
+    const { consume } = createContext();
+    expect(typeof consume).toBe("function");
+  });
 });
 
 describe("A <Provider>", () => {
@@ -129,6 +139,61 @@ describe("A <Consumer>", () => {
           expect(actualValue).toEqual("cupcakes");
         }
       );
+    });
+  });
+});
+
+describe("provide", () => {
+  it("places the expected value on the context", () => {
+    let node = document.createElement("div");
+    
+    const defaultValue = "licorice";
+    let actualValue;
+    let providedValue = "taffy";
+
+    const { provide, Consumer } = createContext(defaultValue);
+    const SweetsProvider = ({ value, children }) => (
+      provide(value, children)
+    );
+    
+    ReactDOM.render((
+      <SweetsProvider value={providedValue}>
+        <Consumer>
+          {value => {
+            actualValue = value;
+            return null;
+          }}
+        </Consumer>
+      </SweetsProvider>
+    ), node, () => {
+      expect(actualValue).toBe(providedValue);
+    });
+  });
+});
+
+describe("consume", () => {
+  it("is called with the correct value", () => {
+    let node = document.createElement("div");
+
+    const defaultValue = "chocolate";
+    let actualValue;
+    let providedValue = "popsicle";
+
+    const { Provider, consume } = createContext(defaultValue);
+
+    const SweetTooth = () => (
+      consume(value => {
+        actualValue = value;
+        return null;
+      })
+    );
+
+    ReactDOM.render((
+      <Provider value={providedValue}>
+        <SweetTooth />
+      </Provider>
+    ), node, () => {
+      expect(actualValue).toBe(providedValue);
     });
   });
 });

--- a/modules/createContext.js
+++ b/modules/createContext.js
@@ -27,6 +27,22 @@ function createContext(defaultValue) {
   const valueType = getPropType(defaultValue);
   const channel = uid++;
 
+  const provide = (value, children) => {
+    return (
+      <Provider value={value}>
+        {children}
+      </Provider>
+    );
+  };
+
+  const consume = (render) => {
+    return (
+      <Consumer>
+        {render}
+      </Consumer>
+    );
+  };
+
   /**
    * A <Provider> is a container for a "value" that its <Consumer>
    * may subscribe to.
@@ -154,6 +170,8 @@ function createContext(defaultValue) {
   }
 
   return {
+    provide,
+    consume,
     Provider,
     Consumer
   };


### PR DESCRIPTION
Per https://github.com/facebook/react/pull/11818 ([code here](https://github.com/acdlite/react/blob/0276eb5c5b27ea6ac251c42bd83211c7d486ab16/packages/shared/ReactContext.js#L47-L74)), adds `provide` and `consume` functions to the output of `createContext`.

These functions are really just wrappers around `<Provider>` and `<Consumer>`.

This PR skips the optional arguments passed to `provide` (`key`) and `consume` (`key` and `observedBits`). They can added easily enough, but I just wanted to start with a minimum viable pull request.