### PR TITLE
Fix Consumer not getting updated value with nested Provider

### DIFF
--- a/modules/__tests__/createContext-test.js
+++ b/modules/__tests__/createContext-test.js
@@ -196,8 +196,6 @@ describe("nested <Provider>", () => {
       }
     }
 
-    let childDidRender = false;
-
     class Child extends React.Component {
       render() {
         return (

--- a/modules/__tests__/createContext-test.js
+++ b/modules/__tests__/createContext-test.js
@@ -132,3 +132,90 @@ describe("A <Consumer>", () => {
     });
   });
 });
+
+describe("nested <Provider>", () => {
+  let node;
+  beforeEach(() => {
+    node = document.createElement("div");
+  });
+
+  it("gets the updated broadcast value as it changes", done => {
+    const ParentContext = createContext("cupcakes");
+    const ChildContext = createContext();
+
+    class UpdateBlocker extends React.Component {
+      shouldComponentUpdate() {
+        return false;
+      }
+
+      render() {
+        return this.props.children;
+      }
+    }
+
+    class AsyncRender extends React.Component {
+      state = {
+        shouldRender: false
+      };
+
+      componentDidMount() {
+        // simulate asynchronous rendering
+        setTimeout(() => {
+          this.setState({
+            shouldRender: true
+          });
+        });
+      }
+
+      render() {
+        return this.state.shouldRender && this.props.children;
+      }
+    }
+
+    class Parent extends React.Component {
+      state = {
+        value: ParentContext.Provider.defaultValue
+      };
+
+      render() {
+        return (
+          <ParentContext.Provider value={this.state.value}>
+            <button
+              onClick={() => this.setState({ value: "bubblegum" })}
+              ref={node => (this.button = node)}
+            />
+            <UpdateBlocker>
+              <ChildContext.Provider>
+                <AsyncRender>
+                  <Child />
+                </AsyncRender>
+              </ChildContext.Provider>
+            </UpdateBlocker>
+          </ParentContext.Provider>
+        );
+      }
+    }
+
+    let childDidRender = false;
+
+    class Child extends React.Component {
+      render() {
+        return (
+          <ParentContext.Consumer
+            children={value => {
+              expect(value).toBe("bubblegum");
+
+              done();
+
+              return null;
+            }}
+          />
+        );
+      }
+    }
+
+    ReactDOM.render(<Parent />, node, function() {
+      Simulate.click(this.button);
+    });
+  });
+});

--- a/modules/createContext.js
+++ b/modules/createContext.js
@@ -64,13 +64,17 @@ function createContext(defaultValue) {
       };
     };
 
+    getValue = () => {
+      return this.props.value;
+    };
+
     getChildContext() {
       return {
         broadcasts: {
           ...this.context.broadcasts,
           [channel]: {
             subscribe: this.subscribe,
-            value: this.props.value
+            getValue: this.getValue
           }
         }
       };
@@ -108,7 +112,7 @@ function createContext(defaultValue) {
     broadcast = this.context.broadcasts && this.context.broadcasts[channel];
 
     state = {
-      value: this.broadcast ? this.broadcast.value : defaultValue
+      value: this.broadcast ? this.broadcast.getValue() : defaultValue
     };
 
     componentDidMount() {


### PR DESCRIPTION
## Problem
The current implementation has a bug when nested `<Provider>` is used, the async rendered consumer won't get updated value. This bug is demonstrated in the test and also on [codesandbox](https://codesandbox.io/s/388mo3xkoq).

Also note that using [`create-react-context`](https://github.com/thejameskyle/create-react-context) by @thejameskyle works. You can comment the import statement and change to `create-react-context` in the codesandbox and the result should be different.

## Solution
The fix is relatively easy to just switch to use `getValue()` instead of `value`.

I'm not really sure why this happens. My guess is that when the child is asynchronously rendered, the constructor will get the child's <Provider> context instead of parent's, which will remain the old value since the initial render. Note that it requires some update blocking in `shouldComponentUpdate` return false, so the child provider won't update it's `broadcasts` value in context.

Using getter function so that the context isn't changed all along. We only get the value when we call the function, so even if the context never changes, we can guarantee to get the updated value.

## Check List
- [x] Add test
- [x] Backward compatible

--- 

I've been struggling with this bug for the past two days and it was hard to reproduce 😂 . Glad I finally found the root cause and I hope this help! Please let me know about anything I can do. Really appreciate!