### PR TITLE
Do not bundle dependencies in cjs/esm builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,6 +30,7 @@ const varName = pascalCase(packageName);
 exec(
   `rollup -c scripts/config.js -f umd -n ${varName} -o umd/${packageName}.js`,
   {
+    EXTERNALS: "peers",
     BUILD_ENV: "development"
   }
 );
@@ -37,6 +38,7 @@ exec(
 exec(
   `rollup -c scripts/config.js -f umd -n ${varName} -o umd/${packageName}.min.js`,
   {
+    EXTERNALS: "peers",
     BUILD_ENV: "production"
   }
 );

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -3,6 +3,16 @@ const commonjs = require("rollup-plugin-commonjs");
 const replace = require("rollup-plugin-replace");
 const resolve = require("rollup-plugin-node-resolve");
 const uglify = require("rollup-plugin-uglify");
+const pkg = require("../package.json");
+
+const getExternals = externals => {
+  const deps = Object.keys(pkg.dependencies || {})
+  const peers = Object.keys(pkg.peerDependencies || {})
+
+  return externals === 'peers'
+    ? peers
+    : deps.concat(peers)
+}
 
 const getPlugins = env => {
   const plugins = [resolve()];
@@ -45,7 +55,7 @@ const config = {
       react: "React"
     }
   },
-  external: ["react"],
+  external: getExternals(process.env.EXTERNALS),
   plugins: getPlugins(process.env.BUILD_ENV)
 };
 


### PR DESCRIPTION
**cjs build - minified & gzipped**

**pre** - 5316 bytes
**post** - 2069 bytes

size reduction - 61% 💰 

